### PR TITLE
Facilitate switching between sandbox and production environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,28 @@ Add the following config to your config.exs file:
 ```elixir
 config :ex_yapay,
   base_url: System.get_env("YAPAY_URL") || "https://intermediador.yapay.com.br",
+  request_post_prefix: System.get_env("YAPAY_REQUEST_POST_PREFIX") || "tc.",
   ibrowse_opts: [],
   timeout: 10000
 ```
+
+Both `YAPAY_URL` and `YAPAY_REQUEST_POST_PREFIX` will need to be set differently depending on the environment:
+
+#### Sandbox
+
+```bash
+YAPAY_URL=https://intermediador-sandbox.yapay.com.br
+YAPAY_REQUEST_POST_PREFIX=tc-
+```
+
+#### Production
+
+```bash
+YAPAY_URL=https://intermediador.yapay.com.br
+YAPAY_REQUEST_POST_PREFIX=tc.
+```
+
+In case none of these are set, the environment you are using is assumed to be production.
 
 ### Create a Transaction
 

--- a/lib/ex_yapay/client/request.ex
+++ b/lib/ex_yapay/client/request.ex
@@ -7,12 +7,10 @@ defmodule ExYapay.Client.Request do
 
   @post_default_headers [{"Content-Type", "application/x-www-form-urlencoded"}]
   @get_default_headers [{"Content-Type", "application/json"}]
-  @post_prefix Application.get_env(:ex_yapay, :request_post_prefix, "tc.")
-  @get_prefix Application.get_env(:ex_yapay, :request_get_prefix, "api.")
 
   def post(path, body, headers \\ @post_default_headers) do
     path
-    |> build_url(@post_prefix)
+    |> build_url(post_prefix())
     |> log_request_info(body)
     |> HTTPotion.post(body: body, headers: headers, ibrowse: ibrowse_opts(), timeout: timeout())
     |> process()
@@ -20,7 +18,7 @@ defmodule ExYapay.Client.Request do
 
   def get(path, headers \\ @get_default_headers) do
     path
-    |> build_url(@get_prefix)
+    |> build_url(get_prefix())
     |> log_request_info()
     |> HTTPotion.get(ibrowse: ibrowse_opts(), headers: headers, timeout: timeout())
     |> process()
@@ -79,4 +77,8 @@ defmodule ExYapay.Client.Request do
   defp ibrowse_opts, do: Application.get_env(:ex_yapay, :ibrowse_opts, [])
 
   defp timeout, do: Application.get_env(:ex_yapay, :timeout, 10_000)
+
+  defp post_prefix, do: Application.get_env(:ex_yapay, :request_post_prefix, "tc.")
+
+  defp get_prefix, do: Application.get_env(:ex_yapay, :request_get_prefix, "api.")
 end


### PR DESCRIPTION
## Objective

Yapay has changed their url, alongside its prefix, in the sandbox environment. Thus, the value of these variables are going to need to be set differently depending on the environment.

## Proposed solution

Change both `request_post_prefix` and `request_get_prefix` from module attributes to private functions, so we can read them at runtime. The README was also updated to better reflect what needs to be done in terms of configurating these variables.